### PR TITLE
1.0 freeze gate: API/doc alignment and release validation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,7 @@ jobs:
           extra-packages: |
             any::covr
             any::testthat
+            any::xml2
           needs: coverage
 
       - name: Compute coverage and enforce threshold

--- a/2.CheatsheetV8.r
+++ b/2.CheatsheetV8.r
@@ -408,7 +408,7 @@ p_test(x = 21, n = 100, p0 = 0.20, alternative = "greater")
 p_test(x = 8, n = 10, p0 = 0.60, alternative = "greater")
 # Two-sample equality test: default pooled, no continuity correction
 p_test(x = c(35, 24), n = c(100, 100), p0 = 0)
-p_test(x = c(344, 156), n = c(4000, 4000), p0 = 0, pooled = FALSE)
+p_test(x = c(344, 156), n = c(4000, 4000), p0 = 0)
 # Two-sample equality test: explicit unpooled version
 p_test(x = c(35, 24), n = c(100, 100), p0 = 0, pooled = FALSE)
 

--- a/StatsPackage -1.0/vignettes/getting-started.Rmd
+++ b/StatsPackage -1.0/vignettes/getting-started.Rmd
@@ -58,6 +58,16 @@ var_test_chisq(s = 4.2, n = 12, sigma0 = 5, alternative = "two.sided", quiet = T
 ```{r}
 obs <- c(18, 35, 31, 16)
 chisq_gof_probs(observed = obs, p = c(0.2, 0.3, 0.3, 0.2), quiet = TRUE)
+chisq_gof_dist(
+  x = c(0.02, 0.05, 0.08, 0.15,
+        0.28, 0.31, 0.33, 0.37, 0.41, 0.45,
+        0.53, 0.56, 0.59, 0.63, 0.68, 0.72,
+        0.76, 0.79, 0.83, 0.87, 0.89, 0.91, 0.95, 0.99),
+  dist = "unif",
+  k = 4,
+  estimate = TRUE,
+  quiet = TRUE
+)
 ```
 
 ```{r}

--- a/docs/API_INDEX.md
+++ b/docs/API_INDEX.md
@@ -35,7 +35,7 @@ For argument-level help in R, use `?function_name` after loading the package.
 | Function | Summary |
 | --- | --- |
 | `chisq_gof_probs()` | Goodness-of-fit test to specified category probabilities |
-| `chisq_gof_dist()` | Goodness-of-fit test to distributions (`pois`, `norm`, `exp`) |
+| `chisq_gof_dist()` | Goodness-of-fit test to distributions (`pois`, `norm`, `exp`, `unif`) |
 | `chisq_table()` | Chi-square test for independence/homogeneity in contingency tables |
 | `table_props()` | Row/column/overall descriptive proportions for contingency tables |
 
@@ -74,4 +74,3 @@ Most families follow these conventions:
 - `quiet = TRUE` suppresses printed output
 - return values are invisible, classed objects with full computational fields
 - result objects include decision-critical fields such as statistic, p-value or power/beta, and rejection region/critical values when relevant
-

--- a/scripts/qa_cheatsheet_audit.R
+++ b/scripts/qa_cheatsheet_audit.R
@@ -19,7 +19,7 @@ if (!requireNamespace("devtools", quietly = TRUE)) {
   stop("devtools is required for the cheat sheet audit.")
 }
 
-devtools::install(pkg_dir, upgrade = "never", quiet = TRUE, dependencies = FALSE)
+devtools::install(pkg_dir, upgrade = FALSE, quiet = TRUE, dependencies = FALSE)
 suppressPackageStartupMessages(library(StatsPackage))
 
 lines <- readLines(cheat_path, warn = FALSE, encoding = "UTF-8")

--- a/scripts/qa_smoke_release.R
+++ b/scripts/qa_smoke_release.R
@@ -25,7 +25,7 @@ if (!requireNamespace("StatsPackage", quietly = TRUE)) {
     stop("StatsPackage is not installed. Install it first or install devtools for local fallback install.")
   }
   cat("StatsPackage not found in library. Installing from local package directory...\n")
-  devtools::install(pkg_dir, upgrade = "never", quiet = TRUE, dependencies = FALSE)
+  devtools::install(pkg_dir, upgrade = FALSE, quiet = TRUE, dependencies = FALSE)
 }
 
 suppressPackageStartupMessages(library(StatsPackage))
@@ -190,4 +190,3 @@ cat("Execution log:", log_path, "\n")
 if (n_fail > 0L) {
   stop("Smoke test failed: ", n_fail, " check(s) failed. See results/log under qa/.")
 }
-


### PR DESCRIPTION
## Summary
- validate the `codex/1-0-freeze-gate` branch as the 1.0 API freeze candidate
- keep the package at `0.1.4`; this PR does **not** cut `1.0.0`
- make source-doc alignment fixes only; no API expansion or feature work

## Freeze-pass changes
- update `docs/API_INDEX.md` so `chisq_gof_dist()` documents `unif` support
- fix the stale default-pooled `p_test()` example in `2.CheatsheetV8.r`
- add a valid uniform GOF example to the source vignette

## Local validation already completed
- package tests passed: `381` pass, `0` fail
- `lintr::lint_dir("StatsPackage -1.0/R")`: no lints found
- `Rscript 2.CheatsheetV8.r`: passed
- structured cheat-sheet audit: `0` issues
- smoke test: `6` pass, `0` fail
- clean-session GitHub install from commit `35994860ac362154da1d55210b4c0031d2c6a0a5`: passed

## Notes
- local Windows `devtools::check()` / `R CMD build` hit a tooling-level `Rcmd.exe` crash after successful vignette rebuild
- treat GitHub Actions CI as the authority for release-gate validation unless the same failure reproduces on GitHub-hosted runners

## Merge criteria
- all required checks green:
  - `ubuntu-latest / R-release`
  - `ubuntu-latest / R-devel`
  - `windows-latest / R-release`
  - `macos-latest / R-release`
  - `lintr`
  - `coverage`
- no new API-visible changes introduced during any follow-up fixes
- docs, vignette, cheat sheet, and default-policy docs remain aligned with the `0.1.4` freeze baseline