### PR TITLE
Release 1.0.0: version and release-facing docs

### DIFF
--- a/2.CheatsheetV8.r
+++ b/2.CheatsheetV8.r
@@ -2,7 +2,7 @@
 # you can delete or comment out this block.
 
 
-required_version <- "0.1.4"
+required_version <- "1.0.0"
 
 if (!requireNamespace("remotes", quietly = TRUE)) {
   install.packages("remotes")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project priorities are:
 - reusable workflows beyond a single assignment
 - regression-tested behavior
 
-Current package version: `0.1.4` (post-`0.1.0` stabilization)
+Current package version: `1.0.0` (stable public API)
 
 ## Repository Layout
 
@@ -34,13 +34,13 @@ devtools::install("StatsPackage -1.0")
 library(StatsPackage)
 ```
 
-Install from GitHub (canonical classroom deployment command, pinned to `0.1.4`):
+Install from GitHub (canonical classroom deployment command, pinned to `1.0.0`):
 
 ```r
 remotes::install_github(
   "christopherposadasp-ctrl/StatsRPackage",
   subdir = "StatsPackage -1.0",
-  ref = "0.1.4"
+  ref = "1.0.0"
 )
 library(StatsPackage)
 ```

--- a/StatsPackage -1.0/DESCRIPTION
+++ b/StatsPackage -1.0/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: StatsPackage
 Title: Statistical Functions for Introductory Inference and Design
-Version: 0.1.4
+Version: 1.0.0
 Authors@R: 
     person("Chris", "Posadas", email = "christopher.v.posadas@nps.edu", role = c("aut", "cre"))
 Description: A personal package of reusable statistical functions for confidence intervals,

--- a/StatsPackage -1.0/NEWS.md
+++ b/StatsPackage -1.0/NEWS.md
@@ -1,3 +1,12 @@
+# StatsPackage 1.0.0
+
+- Declare the public API stable for the package's intended introductory
+  inference workflows.
+- Finalize the 1.0 freeze gate with aligned documentation, cheat-sheet
+  regression validation, and release QA automation.
+- Keep exported functions, defaults, and return-object conventions fixed as
+  the 1.0 baseline unless a correctness issue requires a future patch.
+
 # StatsPackage 0.1.4
 
 - Add `dist = "unif"` to `chisq_gof_dist()` for continuous uniform GOF.

--- a/docs/1.0_SCOPE.md
+++ b/docs/1.0_SCOPE.md
@@ -1,17 +1,20 @@
 ﻿# StatsPackage 1.0 Scope
 
-This document defines the current objective for moving `StatsPackage` from post-`0.1.0` stabilization to a true `1.0.0` release.
+This document records the scope and release criteria used to move
+`StatsPackage` from post-`0.1.0` stabilization to the `1.0.0` baseline.
 
 ## Current State
 
-- Current public release: `0.1.4`
+- Current public release: `1.0.0`
 - The package installs successfully and has been used effectively by classmates.
 - Core function families are already present: confidence intervals, hypothesis tests, width planning, power, required sample size, descriptive shape, and chi-square / categorical-data methods.
-- The package is already release-quality, but the public API is still treated as stabilizing rather than permanently frozen.
+- The public API is now treated as stable for the package's intended use.
 
-## 1.0 Objective
+## 1.0 Outcome
 
-The goal of `1.0.0` is to declare that the public API is stable for the package's intended use: reusable introductory statistical inference workflows.
+The `1.0.0` release declares that the public API is stable for the
+package's intended use: reusable introductory statistical inference
+workflows.
 
 That means:
 
@@ -20,7 +23,7 @@ That means:
 - printed summaries and returned result objects are consistent across families
 - the README, vignette, pkgdown site, cheat sheet, and tests all describe the same behavior
 
-## In Scope For 1.0.0
+## Included In 1.0.0
 
 - freeze the current public API unless a clear correctness issue requires a change
 - fix any remaining documentation inconsistencies with actual function behavior
@@ -31,16 +34,16 @@ That means:
   - invisible, classed return objects with computational details
 - keep the package focused on general, reusable inference workflows rather than assignment-specific wrappers
 
-## Out Of Scope Before 1.0.0
+## Still Out Of Scope After 1.0.0
 
 - broad feature expansion without a strong reusable-statistics justification
 - assignment-specific helper wrappers
 - breaking renames or casual default changes
 - replacing stable functions wholesale when a targeted patch is enough
 
-## 1.0 Entry Criteria
+## 1.0 Entry Criteria (Satisfied)
 
-`StatsPackage` is ready for `1.0.0` when all of the following are true:
+`StatsPackage` reached `1.0.0` when all of the following were true:
 
 - the package has been exercised through real use and the API feels frozen
 - `devtools::test()` passes
@@ -53,9 +56,9 @@ That means:
 
 ## Release Approach
 
-- continue using `0.1.x` releases for stabilization patches
-- use those patch releases for bug fixes, doc clarification, QA tightening, and minor pedagogical cleanup
-- move to `1.0.0` only when changes are mostly hardening work rather than API design work
+- the `0.1.x` line was used for stabilization patches
+- those patch releases handled bug fixes, doc clarification, QA tightening, and minor pedagogical cleanup
+- the move to `1.0.0` happened only after changes were mostly hardening work rather than API design work
 - after `1.0.0`, treat argument meanings, defaults, and return-object conventions as stable commitments
 
 ## Candidate Future Tasks
@@ -77,10 +80,11 @@ That means:
 
 ## Decision Rule
 
-For proposed work before `1.0.0`, ask:
+For proposed work after `1.0.0`, ask:
 
-Does this make the current toolkit more reliable, consistent, and easier to trust?
+Does this improve the toolkit without weakening the stable `1.0.0` baseline?
 
-- If yes, it likely belongs in the `1.0.0` hardening scope.
-- If it mainly expands scope, it should usually wait until after `1.0.0`.
+- If yes, it may belong in a future minor or patch release.
+- If it requires breaking names, defaults, or result-object conventions, it
+  does not belong in a routine post-`1.0.0` release.
 

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 Use this checklist when deploying `StatsPackage` to classmates.
 
-Current deployment target: `0.1.4`
+Current deployment target: `1.0.0`
 
 Canonical install command:
 
@@ -10,7 +10,7 @@ Canonical install command:
 remotes::install_github(
   "christopherposadasp-ctrl/StatsRPackage",
   subdir = "StatsPackage -1.0",
-  ref = "0.1.4"
+  ref = "1.0.0"
 )
 library(StatsPackage)
 ```
@@ -22,16 +22,16 @@ library(StatsPackage)
    - `Lint`
    - `Coverage`
    - `Pkgdown`
-2. Confirm release tag `0.1.4` exists and is published (not draft/prerelease).
-3. Confirm README install snippet is pinned to `ref = "0.1.4"`.
+2. Confirm release tag `1.0.0` exists and is published (not draft/prerelease).
+3. Confirm README install snippet is pinned to `ref = "1.0.0"`.
 4. Confirm no uncommitted release-critical local changes.
 
 ## 2) GitHub Click Path
 
 1. Open [StatsRPackage Releases](https://github.com/christopherposadasp-ctrl/StatsRPackage/releases).
-2. Open release `0.1.4`.
+2. Open release `1.0.0`.
 3. Verify:
-   - tag: `0.1.4`
+   - tag: `1.0.0`
    - published status (not draft)
    - assets present
 4. Open [repository README](https://github.com/christopherposadasp-ctrl/StatsRPackage#readme).
@@ -46,7 +46,7 @@ install.packages("remotes")
 remotes::install_github(
   "christopherposadasp-ctrl/StatsRPackage",
   subdir = "StatsPackage -1.0",
-  ref = "0.1.4"
+  ref = "1.0.0"
 )
 library(StatsPackage)
 ci_mu(xbar = 12.4, n = 15, s = 3.2, quiet = TRUE)
@@ -68,9 +68,9 @@ Expected:
 If a deployment issue is found:
 
 1. Stop sharing the broken command/message immediately.
-2. Do not retag or rewrite `0.1.4`.
+2. Do not retag or rewrite `1.0.0`.
 3. Create a hotfix commit on `main`.
-4. Bump package version and notes for the next patch release (for example `0.1.5`).
+4. Bump package version and notes for the next patch release (for example `1.0.1`).
 5. Push new tag and let Release workflow publish it.
 6. Update README pinned `ref` to the new patch tag.
 7. Send corrected classroom install command.


### PR DESCRIPTION
## Summary
- prepare the `1.0.0` release as a small post-freeze release PR
- keep package code, exported surface, defaults, and formulas unchanged
- update only release metadata and release-facing documentation

## Changes
- bump package version from `0.1.4` to `1.0.0`
- add a top `1.0.0` section to `StatsPackage -1.0/NEWS.md`
- update README, deployment checklist, cheat-sheet install pin, and `1.0` scope wording to reflect the stable `1.0.0` baseline

## Local validation
- `devtools::test("StatsPackage -1.0")`: passed (`381` pass, `0` fail)
- `lintr::lint_dir("StatsPackage -1.0/R")`: no lints found
- `devtools::check("StatsPackage -1.0")`: local Windows host still shows the known `Rcmd.exe` native exit after successful build/vignette work; treat GitHub CI as authority unless it reproduces there
- direct cheat-sheet run: passed after installing local `1.0.0`
- structured cheat-sheet audit: `0` issues in `qa/cheatsheet_audit_issues.csv`
- smoke test: `6` pass, `0` fail

## Merge criteria
- `CI`, `Lint`, and `Coverage` green on this PR
- no additional code or API changes added to the branch
- clean GitHub install from the PR head SHA succeeds before merge