### PR TITLE
Fix pkgdown package installation

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -38,7 +38,7 @@ jobs:
           needs: website
 
       - name: Build pkgdown site
-        run: Rscript -e "pkgdown::build_site('StatsPackage -1.0', install = FALSE, new_process = FALSE)"
+        run: Rscript -e "pkgdown::build_site('StatsPackage -1.0', install = TRUE, new_process = FALSE)"
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary

- Update the pkgdown workflow to install `StatsPackage` before building reference pages.
- This fixes the post-merge pkgdown failure where `build_reference()` tried `library(StatsPackage)` and errored because the package was not installed.

## Validation

- Release `1.1.0` already published successfully.
- Clean install from `ref = "1.1.0"` passed locally with `pi_mu()` smoke validation.
- This PR only changes `.github/workflows/pkgdown.yml` and does not move or rewrite the `1.1.0` tag.